### PR TITLE
Update deno run permissions to be more restrictive

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To simplify running the script, you can define a bash alias function:
 
 ```bash
 function etc(){
-  env SERVER_URL="${SERVER_URL:-http://localhost:3000}" rlwrap npx -y deno run -rA https://btwiuse.github.io/eliza-terminal-chat/terminal-chat.ts "$@"
+  env SERVER_URL="${SERVER_URL:-http://localhost:3000}" rlwrap npx -y deno run --allow-env=DEBUG,SERVER_URL --allow-net https://btwiuse.github.io/eliza-terminal-chat/terminal-chat.ts "$@"
 }
 ```
 


### PR DESCRIPTION
Update the bash alias function in `README.md` to use more restrictive permissions.

* Change the alias function to use `--allow-env=DEBUG,SERVER_URL` and `--allow-net` instead of `-rA` in the example command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/eliza-terminal-chat/pull/3?shareId=fa6642f5-4e14-4a89-9c95-76a234b41a23).