### PR TITLE
Split the etc function into several lines to improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,18 @@ To simplify running the script, you can define a bash alias function:
 
 ```bash
 function etc(){
-  env SERVER_URL="${SERVER_URL:-http://localhost:3000}" rlwrap npx -y deno run --allow-env=DEBUG,SERVER_URL --allow-net https://btwiuse.github.io/eliza-terminal-chat/terminal-chat.ts "$@"
+  # Set the SERVER_URL environment variable
+  env SERVER_URL="${SERVER_URL:-http://localhost:3000}" \
+  # Use rlwrap for command line editing
+  rlwrap \
+  # Use npx to run the deno command
+  npx -y deno run \
+  # Allow environment variables DEBUG and SERVER_URL
+  --allow-env=DEBUG,SERVER_URL \
+  # Allow network access
+  --allow-net \
+  # URL to the terminal-chat.ts script
+  https://btwiuse.github.io/eliza-terminal-chat/terminal-chat.ts "$@"
 }
 ```
 


### PR DESCRIPTION
Split the `etc` function in `README.md` into several lines for improved readability.

* Add comments to explain each part of the `etc` function
* Set the `SERVER_URL` environment variable
* Use `rlwrap` for command line editing
* Use `npx` to run the `deno` command
* Allow environment variables `DEBUG` and `SERVER_URL`
* Allow network access
* Include the URL to the `terminal-chat.ts` script

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/eliza-terminal-chat/pull/4?shareId=f221117b-83c8-4272-8fbb-20d32d06f4c2).